### PR TITLE
Expose service errors to users

### DIFF
--- a/qiskit_transpiler_service/wrappers/base.py
+++ b/qiskit_transpiler_service/wrappers/base.py
@@ -173,18 +173,19 @@ def _raise_transpiler_error_and_log(msg: str):
 
 
 def _get_error_msg_from_response(exc: requests.exceptions.HTTPError):
-    if exc.response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY.value:
-        # Default message
-        msg = "Internal error."
-        resp = exc.response.json()
-        if detail := resp.get("detail"):
-            if isinstance(detail, str):
-                msg = detail
-            elif isinstance(detail, list):
-                # Try to get err msg from
-                # raw validation error
-                if "input" in resp["detail"][0] and "msg" in resp["detail"][0]:
-                    msg = f"Wrong input '{resp['detail'][0]['input']}'. {resp['detail'][0]['msg']}"
-    else:
-        msg = f"Service error: {str(exc)}"
+    resp = exc.response.json()
+    print(resp)
+    detail = resp.get("detail")
+    # Default message
+    msg = "Internal error."
+
+    if isinstance(detail, str):
+        msg = detail
+    elif isinstance(detail, list):
+        detail_input = detail[0]['input']
+        detail_msg = detail[0]['msg']
+
+        if detail_input and detail_msg:
+            msg = f"Wrong input '{detail_input}'. {detail_msg}"
+
     return msg


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix https://github.com/Qiskit/qiskit-transpiler-service/issues/2

### Details and comments

To check the code, we first checked the [swagger](https://cloud-transpiler-experimental.quantum-computing.ibm.com/docs#/Transpiler%20methods/transpile_transpile_post) to see the service errors coming from the transpile endpoint. Then we run the `ai-transpiler-demo` jupyter notebook to test through the client and check if we get the same error messages.

We did some checks to make sure error messages are exposed:
- [x] Try to access a backend we don't have access to
- [x] Try to access a backend that doesn't exist
- [x] Try to run a circuit with more gates than allowed
- [x] An input with wrong format
- [ ] I was asked to try to run a task by an unexisting id, but it looks like this check makes no sense on the client
- [ ] Try to run a task that is failing. We had [this](https://github.com/Qiskit/qiskit-transpiler-service/issues/3) code that was failing, but we checked it and it works, so we don't know how to try this check. If any of you have an idea, please let me know

Thank you @victor-villar for helping me building the code to check the different situations