### PR TITLE
Configures Logging for a Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ To complement the synthesis passes we also provide custom collection passes for 
 
 These custom collection passes limit the sizes of the collected sub-circuits so that they are supported by the AI synthesis passes, so it is recommended to use them after the routing passes and before the synthesis passes to get a better optimization overall.
 
+### Customize logs
+
+The library is prepared to let the user log the messages they want. For that, users only have to add the following code to their code:
+
+```python
+import logging
+
+logging.getLogger("qiskit_transpiler_service").setLevel(logging.X)
+```
+
+where X can be: `NOTSET`, `DEBUG`, `INFO`, `WARNING`, `ERROR` or `CRITICAL`
+
 ## Citation
 
 If you use any AI-powered feature from the Qiskit transpiler service in your research, use the following recommended citation:

--- a/ai-transpiler-demo.ipynb
+++ b/ai-transpiler-demo.ipynb
@@ -212,7 +212,7 @@
     "\n",
     "qiskit_lvl3_transpiler_service = TranspilerService(\n",
     "    backend_name=\"ibm_torino\",\n",
-    "    ai='false',\n",
+    "    ai=\"false\",\n",
     "    optimization_level=3,\n",
     ")"
    ]
@@ -281,7 +281,7 @@
    "source": [
     "qiskit_lvl3_ai_transpiler_service = TranspilerService(\n",
     "    backend_name=\"ibm_torino\",\n",
-    "    ai='true',\n",
+    "    ai=\"true\",\n",
     "    optimization_level=3,\n",
     ")"
    ]

--- a/documentation-examples.ipynb
+++ b/documentation-examples.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "cloud_transpiler_service = TranspilerService(\n",
     "    backend_name=\"ibm_sherbrooke\",\n",
-    "    ai='false',\n",
+    "    ai=\"false\",\n",
     "    optimization_level=3,\n",
     ")\n",
     "transpiled_circuit_no_ai = cloud_transpiler_service.run(circuit)"
@@ -50,7 +50,7 @@
     "\n",
     "cloud_transpiler_service = TranspilerService(\n",
     "    backend_name=\"ibm_sherbrooke\",\n",
-    "    ai='true',\n",
+    "    ai=\"true\",\n",
     "    optimization_level=1,\n",
     ")\n",
     "transpiled_circuit_ai = cloud_transpiler_service.run(circuit)"

--- a/qiskit_transpiler_service/__init__.py
+++ b/qiskit_transpiler_service/__init__.py
@@ -13,3 +13,8 @@
 from .ai import AIRouting
 from .transpiler_service import TranspilerService
 from .utils import create_random_linear_function, get_metrics
+
+import logging
+
+logging.basicConfig()
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/qiskit_transpiler_service/ai/routing.py
+++ b/qiskit_transpiler_service/ai/routing.py
@@ -15,8 +15,6 @@
 
 # torch.set_num_threads(1)
 
-import logging
-
 import numpy as np
 from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
@@ -25,10 +23,6 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.layout import Layout
 
 from qiskit_transpiler_service.wrappers import AIRoutingAPI
-
-logging.basicConfig()
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class AIRouting(TransformationPass):

--- a/qiskit_transpiler_service/ai/synthesis.py
+++ b/qiskit_transpiler_service/ai/synthesis.py
@@ -29,7 +29,6 @@ from qiskit_transpiler_service.wrappers import (
 )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 MAX_THREADS = os.environ.get("AI_TRANSPILER_MAX_THREADS", int(cpu_count() / 2))
 

--- a/qiskit_transpiler_service/transpiler_service.py
+++ b/qiskit_transpiler_service/transpiler_service.py
@@ -34,7 +34,6 @@ from qiskit import QuantumCircuit
 from .wrappers.transpile import TranspileAPI
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class TranspilerService:
@@ -57,7 +56,7 @@ class TranspilerService:
     def __init__(
         self,
         optimization_level: int,
-        ai: Literal['true', 'false', 'auto'] = 'true',
+        ai: Literal["true", "false", "auto"] = "true",
         coupling_map: Union[List[List[int]], None] = None,
         backend_name: Union[str, None] = None,
         qiskit_transpile_options: Dict = None,

--- a/qiskit_transpiler_service/wrappers/ai_routing.py
+++ b/qiskit_transpiler_service/wrappers/ai_routing.py
@@ -10,7 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-import logging
 import os
 from urllib.parse import urljoin
 
@@ -18,10 +17,6 @@ from qiskit import QuantumCircuit, qasm2, qasm3
 from qiskit.qasm2 import QASM2ExportError
 
 from .base import QiskitTranspilerService
-
-logging.basicConfig()
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class AIRoutingAPI(QiskitTranspilerService):

--- a/qiskit_transpiler_service/wrappers/base.py
+++ b/qiskit_transpiler_service/wrappers/base.py
@@ -22,9 +22,7 @@ import backoff
 import requests
 from qiskit.transpiler.exceptions import TranspilerError
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class BackendTaskError(Exception):

--- a/qiskit_transpiler_service/wrappers/transpile.py
+++ b/qiskit_transpiler_service/wrappers/transpile.py
@@ -24,9 +24,7 @@ from qiskit_transpiler_service.wrappers import QiskitTranspilerService
 
 # setting backoff logger to error level to avoid too much logging
 logging.getLogger("backoff").setLevel(logging.ERROR)
-logging.basicConfig()
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class TranspileAPI(QiskitTranspilerService):
@@ -43,7 +41,7 @@ class TranspileAPI(QiskitTranspilerService):
         optimization_level: int = 1,
         backend: Union[str, None] = None,
         coupling_map: Union[List[List[int]], None] = None,
-        ai: Literal['true', 'false', 'auto'] = 'true',
+        ai: Literal["true", "false", "auto"] = "true",
         qiskit_transpile_options: Dict = None,
         ai_layout_mode: str = None,
     ):

--- a/tests/ai/test_routing_ai.py
+++ b/tests/ai/test_routing_ai.py
@@ -12,17 +12,12 @@
 
 """Unit-testing routing_ai"""
 
-import logging
-
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit_transpiler_service.ai.routing import AIRouting
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 @pytest.mark.parametrize("layout_mode", ["KEEP", "OPTIMIZE", "IMPROVE"])

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -12,8 +12,6 @@
 
 """Unit-testing Transpiler Service"""
 
-import logging
-
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit, qasm2, qasm3
@@ -25,14 +23,11 @@ from qiskit.quantum_info import SparsePauliOp, random_hermitian
 from qiskit_transpiler_service.transpiler_service import TranspilerService
 from qiskit_transpiler_service.wrappers import _get_circuit_from_result
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
 
 @pytest.mark.parametrize(
     "optimization_level", [1, 2, 3], ids=["opt_level_1", "opt_level_2", "opt_level_3"]
 )
-@pytest.mark.parametrize("ai", ['false', 'true'], ids=["no_ai", "ai"])
+@pytest.mark.parametrize("ai", ["false", "true"], ids=["no_ai", "ai"])
 @pytest.mark.parametrize(
     "qiskit_transpile_options",
     [None, {"seed_transpiler": 0}],
@@ -56,7 +51,7 @@ def test_rand_circ_backend_routing(optimization_level, ai, qiskit_transpile_opti
 @pytest.mark.parametrize(
     "optimization_level", [1, 2, 3], ids=["opt_level_1", "opt_level_2", "opt_level_3"]
 )
-@pytest.mark.parametrize("ai", ['false', 'true'], ids=["no_ai", "ai"])
+@pytest.mark.parametrize("ai", ["false", "true"], ids=["no_ai", "ai"])
 @pytest.mark.parametrize(
     "qiskit_transpile_options",
     [None, {"seed_transpiler": 0}],
@@ -85,7 +80,7 @@ def test_qv_backend_routing(optimization_level, ai, qiskit_transpile_options):
     ],
 )
 @pytest.mark.parametrize("optimization_level", [1, 2, 3])
-@pytest.mark.parametrize("ai", ['false', 'true'], ids=["no_ai", "ai"])
+@pytest.mark.parametrize("ai", ["false", "true"], ids=["no_ai", "ai"])
 @pytest.mark.parametrize("qiskit_transpile_options", [None, {"seed_transpiler": 0}])
 def test_rand_circ_cmap_routing(
     coupling_map, optimization_level, ai, qiskit_transpile_options
@@ -108,7 +103,7 @@ def test_qv_circ_several_circuits_routing():
 
     cloud_transpiler_service = TranspilerService(
         backend_name="ibm_brisbane",
-        ai='true',
+        ai="true",
         optimization_level=1,
     )
     transpiled_circuit = cloud_transpiler_service.run([qv_circ] * 2)
@@ -129,7 +124,7 @@ def test_qv_circ_wrong_input_routing():
 
     cloud_transpiler_service = TranspilerService(
         backend_name="ibm_brisbane",
-        ai='true',
+        ai="true",
         optimization_level=1,
     )
 
@@ -138,7 +133,7 @@ def test_qv_circ_wrong_input_routing():
         cloud_transpiler_service.run(circ_dict)
 
 
-@pytest.mark.parametrize("ai", ['false', 'true'], ids=["no_ai", "ai"])
+@pytest.mark.parametrize("ai", ["false", "true"], ids=["no_ai", "ai"])
 def test_transpile_layout_reconstruction(ai):
     n_qubits = 27
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes https://github.com/Qiskit/qiskit-transpiler-service/issues/1

### Details and comments

This PR configures Logging for our library to allow the final user to easily control or override the level of messages he/she wants to see.

To fix this issue I have followed these docs:

- [Configuring Logging for a Library](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library)
- [Library vs Application Logging: What Is NullHandler?](https://realpython.com/python-logging-source-code/#library-vs-application-logging-what-is-nullhandler)


