### PR TITLE
Enable programmatic config of polling timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### 🎉 Added
 
+- [#28](https://github.com/Qiskit/qiskit-transpiler-service/pull/28) Enable programatic config of polling timeout
+
 ### ✏️ Changed
 
 ### 🐛 Fixed

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@
 log_cli = true
 log_cli_format = %(asctime)s  %(levelname)s %(message)s (%(filename)s:%(lineno)s)
 log_cli_date_format=%Y-%m-%d %H:%M:%S
+markers =
+    disable_monkeypatch: Disable monkeypatch of env vars for some tests

--- a/qiskit_transpiler_service/ai/routing.py
+++ b/qiskit_transpiler_service/ai/routing.py
@@ -46,6 +46,7 @@ class AIRouting(TransformationPass):
         coupling_map=None,
         optimization_level: int = 2,
         layout_mode: str = "OPTIMIZE",
+        **kwargs,
     ):
         super().__init__()
         if backend_name is not None and coupling_map is not None:
@@ -77,7 +78,7 @@ class AIRouting(TransformationPass):
                 f"ERROR. Unknown ai_layout_mode: {layout_mode}. Valid modes: 'KEEP', 'OPTIMIZE', 'IMPROVE'"
             )
         self.layout_mode = layout_mode.upper()
-        self.service = AIRoutingAPI()
+        self.service = AIRoutingAPI(**kwargs)
 
     def run(self, dag):
         """Run the AIRouting pass on `dag`.

--- a/qiskit_transpiler_service/ai/synthesis.py
+++ b/qiskit_transpiler_service/ai/synthesis.py
@@ -127,10 +127,10 @@ class AICliffordSynthesis(AISynthesis):
     """
 
     def __init__(
-        self, backend_name, replace_only_if_better=True, max_threads=None
+        self, backend_name, replace_only_if_better=True, max_threads=None, **kwargs
     ) -> None:
         super().__init__(
-            backend_name, AICliffordAPI(), replace_only_if_better, max_threads
+            backend_name, AICliffordAPI(**kwargs), replace_only_if_better, max_threads
         )
 
     def _get_synth_input_and_original(self, node):
@@ -164,10 +164,13 @@ class AILinearFunctionSynthesis(AISynthesis):
     """
 
     def __init__(
-        self, backend_name, replace_only_if_better=True, max_threads=None
+        self, backend_name, replace_only_if_better=True, max_threads=None, **kwargs
     ) -> None:
         super().__init__(
-            backend_name, AILinearFunctionAPI(), replace_only_if_better, max_threads
+            backend_name,
+            AILinearFunctionAPI(**kwargs),
+            replace_only_if_better,
+            max_threads,
         )
 
     def _get_synth_input_and_original(self, node):
@@ -197,10 +200,13 @@ class AIPermutationSynthesis(AISynthesis):
     """
 
     def __init__(
-        self, backend_name, replace_only_if_better=True, max_threads=None
+        self, backend_name, replace_only_if_better=True, max_threads=None, **kwargs
     ) -> None:
         super().__init__(
-            backend_name, AIPermutationAPI(), replace_only_if_better, max_threads
+            backend_name,
+            AIPermutationAPI(**kwargs),
+            replace_only_if_better,
+            max_threads,
         )
 
     def _get_synth_input_and_original(self, node):

--- a/qiskit_transpiler_service/transpiler_service.py
+++ b/qiskit_transpiler_service/transpiler_service.py
@@ -61,10 +61,11 @@ class TranspilerService:
         backend_name: Union[str, None] = None,
         qiskit_transpile_options: Dict = None,
         ai_layout_mode: str = None,
+        **kwargs,
     ) -> None:
         """Initializes the instance."""
 
-        self.transpiler_service = TranspileAPI()
+        self.transpiler_service = TranspileAPI(**kwargs)
 
         self.backend_name = backend_name
         self.coupling_map = coupling_map

--- a/qiskit_transpiler_service/wrappers/ai_routing.py
+++ b/qiskit_transpiler_service/wrappers/ai_routing.py
@@ -22,8 +22,8 @@ from .base import QiskitTranspilerService
 class AIRoutingAPI(QiskitTranspilerService):
     """A helper class that covers some basic funcionality from the AIRouting API"""
 
-    def __init__(self):
-        super().__init__("routing")
+    def __init__(self, **kwargs):
+        super().__init__(path_param="routing", **kwargs)
 
     def routing(
         self,

--- a/qiskit_transpiler_service/wrappers/ai_synthesis.py
+++ b/qiskit_transpiler_service/wrappers/ai_synthesis.py
@@ -26,8 +26,8 @@ logging.getLogger(__name__).setLevel(logging.INFO)
 class AICliffordAPI(QiskitTranspilerService):
     """A helper class that covers some basic funcionality from the Clifford AI Synthesis API"""
 
-    def __init__(self):
-        super().__init__("clifford")
+    def __init__(self, **kwargs):
+        super().__init__(path_param="clifford", **kwargs)
 
     def transpile(
         self,
@@ -56,8 +56,8 @@ class AICliffordAPI(QiskitTranspilerService):
 class AILinearFunctionAPI(QiskitTranspilerService):
     """A helper class that covers some basic funcionality from the Linear Function AI Synthesis API"""
 
-    def __init__(self):
-        super().__init__("linear_functions")
+    def __init__(self, **kwargs):
+        super().__init__(path_param="linear_functions", **kwargs)
 
     def transpile(
         self,
@@ -86,8 +86,8 @@ class AILinearFunctionAPI(QiskitTranspilerService):
 class AIPermutationAPI(QiskitTranspilerService):
     """A helper class that covers some basic funcionality from the Permutation AI Synthesis API"""
 
-    def __init__(self):
-        super().__init__("permutations")
+    def __init__(self, **kwargs):
+        super().__init__(path_param="permutations", **kwargs)
 
     def transpile(
         self,

--- a/qiskit_transpiler_service/wrappers/base.py
+++ b/qiskit_transpiler_service/wrappers/base.py
@@ -60,6 +60,7 @@ class QiskitTranspilerService:
         path_param=None,
         base_url: str = "https://cloud-transpiler.quantum.ibm.com/",
         token: str = None,
+        timeout: int = 300,
     ):
         # If it does not recive URL or token, the function tries to find your Qiskit
         # token from the QISKIT_IBM_TOKEN env var
@@ -74,6 +75,8 @@ class QiskitTranspilerService:
         self.url = os.environ.get(url_env_var, url_with_path).rstrip("/")
 
         token = token if token else _get_token_from_system()
+
+        self.timeout = timeout
 
         self.headers = {
             "Accept": "application/json",
@@ -100,27 +103,32 @@ class QiskitTranspilerService:
 
         return resp
 
-    @backoff.on_predicate(
-        backoff.constant,
-        lambda res: res.get("state") not in ["SUCCESS", "FAILURE"],
-        jitter=None,
-        interval=1,  # TODO: Define by config or circuit?
-        max_time=600,  # TODO: Define by config or circuit?
-    )
-    @backoff.on_exception(
-        backoff.expo,
-        (
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.JSONDecodeError,
-        ),
-        max_time=600,  # TODO: Define by config or circuit?
-    )
     def request_status(self, endpoint, task_id):
-        logger.debug(f"Getting status of task {task_id} ...")
-        res = requests.get(url=f"{self.url}/{endpoint}/{task_id}", headers=self.headers)
-        res.raise_for_status()
-        return res.json()
+        @backoff.on_predicate(
+            backoff.constant,
+            lambda res: res.get("state") not in ["SUCCESS", "FAILURE"],
+            jitter=None,
+            interval=1,  # TODO: Define by config or circuit?
+            max_time=self.timeout,
+        )
+        @backoff.on_exception(
+            backoff.expo,
+            (
+                requests.exceptions.Timeout,
+                requests.exceptions.ConnectionError,
+                requests.exceptions.JSONDecodeError,
+            ),
+            max_time=self.timeout,
+        )
+        def _request_status(self, endpoint, task_id):
+            logger.debug(f"Getting status of task {task_id} ...")
+            res = requests.get(
+                url=f"{self.url}/{endpoint}/{task_id}", headers=self.headers
+            )
+            res.raise_for_status()
+            return res.json()
+
+        _request_status(self, endpoint, task_id)
 
     def request_and_wait(self, endpoint: str, body: Dict, params: Dict):
         try:
@@ -145,16 +153,27 @@ class QiskitTranspilerService:
         task_id = resp.get("task_id")
 
         result = BackendTaskError(
-            status="PENDING", msg=f"The background task {task_id} timed out"
+            status="PENDING",
+            msg=f"The background task {task_id} timed out in the server",
         )
 
         resp = self.request_status(endpoint, task_id)
-        if resp.get("state") == "SUCCESS":
-            result = resp.get("result")
-        elif resp.get("state") == "FAILURE":
+        if resp is not None:
+            if resp.get("state") == "SUCCESS":
+                result = resp.get("result")
+            elif resp.get("state") == "FAILURE":
+                logger.error("The request FAILED")
+                result = BackendTaskError(
+                    status="FAILURE", msg=f"The background task {task_id} FAILED"
+                )
+        else:
             logger.error("The request FAILED")
             result = BackendTaskError(
-                status="FAILURE", msg=f"The background task {task_id} FAILED"
+                status="TIMEOUT",
+                msg=(
+                    f"The background task {task_id} reached "
+                    f"the timeout defined in this client ({self.timeout}s)"
+                ),
             )
 
         if isinstance(result, BackendTaskError):

--- a/qiskit_transpiler_service/wrappers/transpile.py
+++ b/qiskit_transpiler_service/wrappers/transpile.py
@@ -30,8 +30,8 @@ logger = logging.getLogger(__name__)
 class TranspileAPI(QiskitTranspilerService):
     """A helper class that covers some basic funcionality from the Qiskit Transpiler API"""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def transpile(
         self,

--- a/tests/ai/test_clifford_ai.py
+++ b/tests/ai/test_clifford_ai.py
@@ -11,33 +11,22 @@
 # that they have been altered from the originals.
 
 """Unit-testing clifford_ai"""
+import pytest
 from qiskit import QuantumCircuit
 from qiskit.transpiler import PassManager
 
 from qiskit_transpiler_service.ai.collection import CollectCliffords
 from qiskit_transpiler_service.ai.synthesis import AICliffordSynthesis
-import pytest
-
-
-def test_clifford_function(random_circuit_transpiled, backend):
-    ai_optimize_lf = PassManager(
-        [
-            CollectCliffords(),
-            AICliffordSynthesis(backend_name=backend),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
 def test_clifford_wrong_backend(random_circuit_transpiled, caplog):
-    ai_optimize_lf = PassManager(
+    ai_optimize_cliff = PassManager(
         [
             CollectCliffords(),
             AICliffordSynthesis(backend_name="wrong_backend"),
         ]
     )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
     assert (
@@ -51,53 +40,51 @@ def test_clifford_wrong_backend(random_circuit_transpiled, caplog):
     reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
 )
 def test_clifford_exceed_timeout(random_circuit_transpiled, backend, caplog):
-    ai_optimize_lf = PassManager(
+    ai_optimize_cliff = PassManager(
         [
             CollectCliffords(),
             AICliffordSynthesis(backend_name=backend, timeout=1),
         ]
     )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
 def test_clifford_wrong_token(random_circuit_transpiled, backend, caplog):
-    ai_optimize_lf = PassManager(
+    ai_optimize_cliff = PassManager(
         [
             CollectCliffords(),
             AICliffordSynthesis(backend_name=backend, token="invented_token_2"),
         ]
     )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
     assert "Invalid authentication credentials" in caplog.text
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
-def test_clifford_wrong_url(monkeypatch, random_circuit_transpiled, backend):
-    monkeypatch.undo()
-    ai_optimize_lf = PassManager(
+@pytest.mark.disable_monkeypatch
+def test_clifford_wrong_url(random_circuit_transpiled, backend):
+    ai_optimize_cliff = PassManager(
         [
             CollectCliffords(),
             AICliffordSynthesis(backend_name=backend, base_url="https://ibm.com/"),
         ]
     )
     try:
-        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+        ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
         pytest.fail("Error expected")
     except Exception as e:
         assert "Expecting value: line 1 column 1 (char 0)" in str(e)
         assert type(e).__name__ == "JSONDecodeError"
 
 
-def test_clifford_unexisting_url(
-    monkeypatch, random_circuit_transpiled, backend, caplog
-):
-    monkeypatch.undo()
-    ai_optimize_lf = PassManager(
+@pytest.mark.disable_monkeypatch
+def test_clifford_unexisting_url(random_circuit_transpiled, backend, caplog):
+    ai_optimize_cliff = PassManager(
         [
             CollectCliffords(),
             AICliffordSynthesis(
@@ -106,11 +93,22 @@ def test_clifford_unexisting_url(
             ),
         ]
     )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
     assert (
         "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
         in caplog.text
     )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_clifford_function(random_circuit_transpiled, backend):
+    ai_optimize_cliff = PassManager(
+        [
+            CollectCliffords(),
+            AICliffordSynthesis(backend_name=backend),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_cliff.run(random_circuit_transpiled)
     assert isinstance(ai_optimized_circuit, QuantumCircuit)

--- a/tests/ai/test_clifford_ai.py
+++ b/tests/ai/test_clifford_ai.py
@@ -16,6 +16,7 @@ from qiskit.transpiler import PassManager
 
 from qiskit_transpiler_service.ai.collection import CollectCliffords
 from qiskit_transpiler_service.ai.synthesis import AICliffordSynthesis
+import pytest
 
 
 def test_clifford_function(random_circuit_transpiled, backend):
@@ -39,4 +40,79 @@ def test_clifford_wrong_backend(random_circuit_transpiled, caplog):
     ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
+    assert (
+        "User doesn't have access to the specified backend: wrong_backend"
+        in caplog.text
+    )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+@pytest.mark.skip(
+    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
+)
+def test_clifford_exceed_timeout(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectCliffords(),
+            AICliffordSynthesis(backend_name=backend, timeout=1),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_clifford_wrong_token(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectCliffords(),
+            AICliffordSynthesis(backend_name=backend, token="invented_token_2"),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert "Invalid authentication credentials" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_clifford_wrong_url(monkeypatch, random_circuit_transpiled, backend):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectCliffords(),
+            AICliffordSynthesis(backend_name=backend, base_url="https://ibm.com/"),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Expecting value: line 1 column 1 (char 0)" in str(
+            e
+        )
+        assert type(e).__name__ == "JSONDecodeError"
+
+
+def test_clifford_unexisting_url(
+    monkeypatch, random_circuit_transpiled, backend, caplog
+):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectCliffords(),
+            AICliffordSynthesis(
+                backend_name=backend,
+                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
+            ),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert (
+        "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
+        in caplog.text
+    )
     assert isinstance(ai_optimized_circuit, QuantumCircuit)

--- a/tests/ai/test_clifford_ai.py
+++ b/tests/ai/test_clifford_ai.py
@@ -89,9 +89,7 @@ def test_clifford_wrong_url(monkeypatch, random_circuit_transpiled, backend):
         ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "Expecting value: line 1 column 1 (char 0)" in str(
-            e
-        )
+        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
         assert type(e).__name__ == "JSONDecodeError"
 
 

--- a/tests/ai/test_linear_function_ai.py
+++ b/tests/ai/test_linear_function_ai.py
@@ -99,9 +99,7 @@ def test_linear_function_wrong_url(monkeypatch, random_circuit_transpiled, backe
         ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "Expecting value: line 1 column 1 (char 0)" in str(
-            e
-        )
+        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
         assert type(e).__name__ == "JSONDecodeError"
 
 

--- a/tests/ai/test_linear_function_ai.py
+++ b/tests/ai/test_linear_function_ai.py
@@ -48,6 +48,83 @@ def test_linear_function_wrong_backend(caplog):
     ai_optimized_circuit = ai_optimize_lf.run(circuit)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
+    assert (
+        "User doesn't have access to the specified backend: a_wrong_backend"
+        in caplog.text
+    )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+@pytest.mark.skip(
+    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
+)
+def test_linear_function_exceed_timeout(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectLinearFunctions(),
+            AILinearFunctionSynthesis(backend_name=backend, timeout=1),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_linear_function_wrong_token(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectLinearFunctions(),
+            AILinearFunctionSynthesis(backend_name=backend, token="invented_token_2"),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert "Invalid authentication credentials" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_linear_function_wrong_url(monkeypatch, random_circuit_transpiled, backend):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectLinearFunctions(),
+            AILinearFunctionSynthesis(
+                backend_name=backend, base_url="https://ibm.com/"
+            ),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Expecting value: line 1 column 1 (char 0)" in str(
+            e
+        )
+        assert type(e).__name__ == "JSONDecodeError"
+
+
+def test_linear_function_unexisting_url(
+    monkeypatch, random_circuit_transpiled, backend, caplog
+):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectLinearFunctions(),
+            AILinearFunctionSynthesis(
+                backend_name=backend,
+                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
+            ),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert (
+        "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
+        in caplog.text
+    )
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 

--- a/tests/ai/test_linear_function_ai.py
+++ b/tests/ai/test_linear_function_ai.py
@@ -19,37 +19,18 @@ from qiskit_transpiler_service.ai.collection import CollectLinearFunctions
 from qiskit_transpiler_service.ai.synthesis import AILinearFunctionSynthesis
 
 
-def test_linear_function_pass(random_circuit_transpiled, backend, caplog):
+def test_linear_function_wrong_backend(random_circuit_transpiled, caplog):
     ai_optimize_lf = PassManager(
         [
             CollectLinearFunctions(),
-            AILinearFunctionSynthesis(backend_name=backend),
+            AILinearFunctionSynthesis(backend_name="wrong_backend"),
         ]
     )
     ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
-
-
-def test_linear_function_wrong_backend(caplog):
-    circuit = QuantumCircuit(10)
-    for i in range(8):
-        circuit.cx(i, i + 1)
-    for i in range(8):
-        circuit.h(i)
-    for i in range(8):
-        circuit.cx(i, i + 1)
-    ai_optimize_lf = PassManager(
-        [
-            CollectLinearFunctions(),
-            AILinearFunctionSynthesis(backend_name="a_wrong_backend"),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(circuit)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
     assert (
-        "User doesn't have access to the specified backend: a_wrong_backend"
+        "User doesn't have access to the specified backend: wrong_backend"
         in caplog.text
     )
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
@@ -85,8 +66,8 @@ def test_linear_function_wrong_token(random_circuit_transpiled, backend, caplog)
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
-def test_linear_function_wrong_url(monkeypatch, random_circuit_transpiled, backend):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_linear_function_wrong_url(random_circuit_transpiled, backend):
     ai_optimize_lf = PassManager(
         [
             CollectLinearFunctions(),
@@ -103,10 +84,8 @@ def test_linear_function_wrong_url(monkeypatch, random_circuit_transpiled, backe
         assert type(e).__name__ == "JSONDecodeError"
 
 
-def test_linear_function_unexisting_url(
-    monkeypatch, random_circuit_transpiled, backend, caplog
-):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_linear_function_unexisting_url(random_circuit_transpiled, backend, caplog):
     ai_optimize_lf = PassManager(
         [
             CollectLinearFunctions(),
@@ -156,4 +135,16 @@ def test_linear_function_only_replace_if_better(backend, caplog):
     ai_optimized_circuit = ai_optimize_lf.run(orig_qc)
     assert ai_optimized_circuit == orig_qc
     assert "Keeping the original circuit" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_linear_function_pass(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectLinearFunctions(),
+            AILinearFunctionSynthesis(backend_name=backend),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+
     assert isinstance(ai_optimized_circuit, QuantumCircuit)

--- a/tests/ai/test_linear_function_ai.py
+++ b/tests/ai/test_linear_function_ai.py
@@ -52,6 +52,9 @@ def test_linear_function_exceed_timeout(random_circuit_transpiled, backend, capl
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 def test_linear_function_wrong_token(random_circuit_transpiled, backend, caplog):
     ai_optimize_lf = PassManager(
         [
@@ -66,6 +69,9 @@ def test_linear_function_wrong_token(random_circuit_transpiled, backend, caplog)
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 @pytest.mark.disable_monkeypatch
 def test_linear_function_wrong_url(random_circuit_transpiled, backend):
     ai_optimize_lf = PassManager(
@@ -84,6 +90,9 @@ def test_linear_function_wrong_url(random_circuit_transpiled, backend):
         assert type(e).__name__ == "JSONDecodeError"
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 @pytest.mark.disable_monkeypatch
 def test_linear_function_unexisting_url(random_circuit_transpiled, backend, caplog):
     ai_optimize_lf = PassManager(

--- a/tests/ai/test_permutation_ai.py
+++ b/tests/ai/test_permutation_ai.py
@@ -136,18 +136,14 @@ def test_permutation_wrong_url(monkeypatch, random_circuit_transpiled, backend):
     ai_optimize_lf = PassManager(
         [
             CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(
-                backend_name=backend, base_url="https://ibm.com/"
-            ),
+            AIPermutationSynthesis(backend_name=backend, base_url="https://ibm.com/"),
         ]
     )
     try:
         ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "Expecting value: line 1 column 1 (char 0)" in str(
-            e
-        )
+        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
         assert type(e).__name__ == "JSONDecodeError"
 
 

--- a/tests/ai/test_permutation_ai.py
+++ b/tests/ai/test_permutation_ai.py
@@ -88,10 +88,87 @@ def test_permutation_wrong_backend(caplog):
     ai_optimize_lf = PassManager(
         [
             CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(backend_name="a_wrong_backend"),
+            AIPermutationSynthesis(backend_name="wrong_backend"),
         ]
     )
     ai_optimized_circuit = ai_optimize_lf.run(orig_qc)
     assert "couldn't synthesize the circuit" in caplog.text
     assert "Keeping the original circuit" in caplog.text
+    assert (
+        "User doesn't have access to the specified backend: wrong_backend"
+        in caplog.text
+    )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+@pytest.mark.skip(
+    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
+)
+def test_permutation_exceed_timeout(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name=backend, timeout=1),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_permutation_wrong_token(random_circuit_transpiled, backend, caplog):
+    ai_optimize_lf = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name=backend, token="invented_token_2"),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert "Invalid authentication credentials" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_permutation_wrong_url(monkeypatch, random_circuit_transpiled, backend):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(
+                backend_name=backend, base_url="https://ibm.com/"
+            ),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Expecting value: line 1 column 1 (char 0)" in str(
+            e
+        )
+        assert type(e).__name__ == "JSONDecodeError"
+
+
+def test_permutation_unexisting_url(
+    monkeypatch, random_circuit_transpiled, backend, caplog
+):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(
+                backend_name=backend,
+                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
+            ),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert (
+        "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
+        in caplog.text
+    )
     assert isinstance(ai_optimized_circuit, QuantumCircuit)

--- a/tests/ai/test_permutation_ai.py
+++ b/tests/ai/test_permutation_ai.py
@@ -40,6 +40,92 @@ def permutations_circuit(backend, cmap_backend):
     return orig_qc
 
 
+def test_permutation_wrong_backend(caplog):
+    orig_qc = QuantumCircuit(3)
+    orig_qc.swap(0, 1)
+    orig_qc.swap(1, 2)
+
+    ai_optimize_perm = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name="wrong_backend"),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_perm.run(orig_qc)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert (
+        "User doesn't have access to the specified backend: wrong_backend"
+        in caplog.text
+    )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+@pytest.mark.skip(
+    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
+)
+def test_permutation_exceed_timeout(random_circuit_transpiled, backend, caplog):
+    ai_optimize_perm = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name=backend, timeout=1),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_perm.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_permutation_wrong_token(random_circuit_transpiled, backend, caplog):
+    ai_optimize_perm = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name=backend, token="invented_token_2"),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_perm.run(random_circuit_transpiled)
+    assert "Invalid authentication credentials" in caplog.text
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+@pytest.mark.disable_monkeypatch
+def test_permutation_wrong_url(random_circuit_transpiled, backend):
+    ai_optimize_perm = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(backend_name=backend, base_url="https://ibm.com/"),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_perm.run(random_circuit_transpiled)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
+        assert type(e).__name__ == "JSONDecodeError"
+
+
+@pytest.mark.disable_monkeypatch
+def test_permutation_unexisting_url(random_circuit_transpiled, backend, caplog):
+    ai_optimize_perm = PassManager(
+        [
+            CollectPermutations(min_block_size=2, max_block_size=27),
+            AIPermutationSynthesis(
+                backend_name=backend,
+                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
+            ),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_perm.run(random_circuit_transpiled)
+    assert "couldn't synthesize the circuit" in caplog.text
+    assert "Keeping the original circuit" in caplog.text
+    assert (
+        "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
+        in caplog.text
+    )
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
 def test_permutation_collector(permutations_circuit, backend, cmap_backend):
     qiskit_lvl3_transpiler = generate_preset_pass_manager(
         optimization_level=1, coupling_map=cmap_backend[backend]
@@ -63,108 +149,14 @@ def test_permutation_collector(permutations_circuit, backend, cmap_backend):
     assert not dag.named_nodes("clifford", "Clifford")
 
 
-def test_permutation_pass(permutations_circuit, backend, cmap_backend, caplog):
-    qiskit_lvl3_transpiler = generate_preset_pass_manager(
-        optimization_level=1, coupling_map=cmap_backend[backend]
-    )
-    permutations_circuit = qiskit_lvl3_transpiler.run(permutations_circuit)
+def test_permutation_pass(permutations_circuit, backend, caplog):
 
-    ai_optimize_lf = PassManager(
+    ai_optimize_perm = PassManager(
         [
             CollectPermutations(max_block_size=27),
             AIPermutationSynthesis(backend_name=backend),
         ]
     )
-    ai_optimized_circuit = ai_optimize_lf.run(permutations_circuit)
+    ai_optimized_circuit = ai_optimize_perm.run(permutations_circuit)
     assert "Using the synthesized circuit" in caplog.text
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
-
-
-def test_permutation_wrong_backend(caplog):
-    orig_qc = QuantumCircuit(3)
-    orig_qc.swap(0, 1)
-    orig_qc.swap(1, 2)
-
-    ai_optimize_lf = PassManager(
-        [
-            CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(backend_name="wrong_backend"),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(orig_qc)
-    assert "couldn't synthesize the circuit" in caplog.text
-    assert "Keeping the original circuit" in caplog.text
-    assert (
-        "User doesn't have access to the specified backend: wrong_backend"
-        in caplog.text
-    )
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
-
-
-@pytest.mark.skip(
-    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
-)
-def test_permutation_exceed_timeout(random_circuit_transpiled, backend, caplog):
-    ai_optimize_lf = PassManager(
-        [
-            CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(backend_name=backend, timeout=1),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-    assert "couldn't synthesize the circuit" in caplog.text
-    assert "Keeping the original circuit" in caplog.text
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
-
-
-def test_permutation_wrong_token(random_circuit_transpiled, backend, caplog):
-    ai_optimize_lf = PassManager(
-        [
-            CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(backend_name=backend, token="invented_token_2"),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-    assert "couldn't synthesize the circuit" in caplog.text
-    assert "Keeping the original circuit" in caplog.text
-    assert "Invalid authentication credentials" in caplog.text
-    assert isinstance(ai_optimized_circuit, QuantumCircuit)
-
-
-def test_permutation_wrong_url(monkeypatch, random_circuit_transpiled, backend):
-    monkeypatch.undo()
-    ai_optimize_lf = PassManager(
-        [
-            CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(backend_name=backend, base_url="https://ibm.com/"),
-        ]
-    )
-    try:
-        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-        pytest.fail("Error expected")
-    except Exception as e:
-        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
-        assert type(e).__name__ == "JSONDecodeError"
-
-
-def test_permutation_unexisting_url(
-    monkeypatch, random_circuit_transpiled, backend, caplog
-):
-    monkeypatch.undo()
-    ai_optimize_lf = PassManager(
-        [
-            CollectPermutations(min_block_size=2, max_block_size=27),
-            AIPermutationSynthesis(
-                backend_name=backend,
-                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
-            ),
-        ]
-    )
-    ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
-    assert "couldn't synthesize the circuit" in caplog.text
-    assert "Keeping the original circuit" in caplog.text
-    assert (
-        "Error: HTTPSConnectionPool(host='invented-domain-qiskit-transpiler-service-123.com', port=443):"
-        in caplog.text
-    )
     assert isinstance(ai_optimized_circuit, QuantumCircuit)

--- a/tests/ai/test_permutation_ai.py
+++ b/tests/ai/test_permutation_ai.py
@@ -77,6 +77,9 @@ def test_permutation_exceed_timeout(random_circuit_transpiled, backend, caplog):
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 def test_permutation_wrong_token(random_circuit_transpiled, backend, caplog):
     ai_optimize_perm = PassManager(
         [
@@ -89,6 +92,9 @@ def test_permutation_wrong_token(random_circuit_transpiled, backend, caplog):
     assert isinstance(ai_optimized_circuit, QuantumCircuit)
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 @pytest.mark.disable_monkeypatch
 def test_permutation_wrong_url(random_circuit_transpiled, backend):
     ai_optimize_perm = PassManager(
@@ -105,6 +111,9 @@ def test_permutation_wrong_url(random_circuit_transpiled, backend):
         assert type(e).__name__ == "JSONDecodeError"
 
 
+@pytest.mark.skip(
+    reason="Unreliable many times. We'll research why it fails sporadically"
+)
 @pytest.mark.disable_monkeypatch
 def test_permutation_unexisting_url(random_circuit_transpiled, backend, caplog):
     ai_optimize_perm = PassManager(

--- a/tests/ai/test_routing_ai.py
+++ b/tests/ai/test_routing_ai.py
@@ -50,3 +50,86 @@ def test_qv_routing_wrong_opt_level(optimization_level, backend, qv_circ):
 def test_qv_routing_wrong_layout_mode(layout_mode, backend, qv_circ):
     with pytest.raises(ValueError):
         PassManager([AIRouting(layout_mode=layout_mode, backend_name=backend)])
+
+
+def test_routing_wrong_backend(random_circuit_transpiled):
+    ai_optimize_lf = PassManager(
+        [
+            AIRouting(backend_name="wrong_backend"),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "User doesn't have access to the specified backend: wrong_backend" in str(
+            e
+        )
+
+@pytest.mark.skip(
+    reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
+)
+def test_routing_exceed_timeout(qv_circ, backend):
+    ai_optimize_lf = PassManager(
+        [
+            AIRouting(backend_name=backend, timeout=1),
+        ]
+    )
+    ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
+    assert isinstance(ai_optimized_circuit, QuantumCircuit)
+
+
+def test_routing_wrong_token(qv_circ, backend):
+    ai_optimize_lf = PassManager(
+        [
+            AIRouting(backend_name=backend, token="invented_token_2"),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Invalid authentication credentials" in str(
+            e
+        )
+
+
+def test_routing_wrong_url(monkeypatch, qv_circ, backend):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            AIRouting(backend_name=backend, base_url="https://ibm.com/"),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "Expecting value: line 1 column 1 (char 0)" in str(
+           e
+        )
+        assert type(e).__name__ == "JSONDecodeError"
+
+
+def test_routing_unexisting_url(
+    monkeypatch, qv_circ, backend
+):
+    monkeypatch.undo()
+    ai_optimize_lf = PassManager(
+        [
+            AIRouting(
+                backend_name=backend,
+                base_url="https://invented-domain-qiskit-transpiler-service-123.com/",
+            ),
+        ]
+    )
+    try:
+        ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
+        pytest.fail("Error expected")
+    except Exception as e:
+        print(e)
+        assert (
+            "Error: HTTPSConnectionPool(host=\\\'invented-domain-qiskit-transpiler-service-123.com\\\', port=443):"
+            in str(e)
+        )
+        assert type(e).__name__ == "TranspilerError"

--- a/tests/ai/test_routing_ai.py
+++ b/tests/ai/test_routing_ai.py
@@ -62,9 +62,10 @@ def test_routing_wrong_backend(random_circuit_transpiled):
         ai_optimized_circuit = ai_optimize_lf.run(random_circuit_transpiled)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "User doesn't have access to the specified backend: wrong_backend" in str(
-            e
+        assert (
+            "User doesn't have access to the specified backend: wrong_backend" in str(e)
         )
+
 
 @pytest.mark.skip(
     reason="Unreliable. It passes most of the times with the timeout of 1 second for the current circuits used"
@@ -89,9 +90,7 @@ def test_routing_wrong_token(qv_circ, backend):
         ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "Invalid authentication credentials" in str(
-            e
-        )
+        assert "Invalid authentication credentials" in str(e)
 
 
 def test_routing_wrong_url(monkeypatch, qv_circ, backend):
@@ -105,15 +104,11 @@ def test_routing_wrong_url(monkeypatch, qv_circ, backend):
         ai_optimized_circuit = ai_optimize_lf.run(qv_circ)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "Expecting value: line 1 column 1 (char 0)" in str(
-           e
-        )
+        assert "Expecting value: line 1 column 1 (char 0)" in str(e)
         assert type(e).__name__ == "JSONDecodeError"
 
 
-def test_routing_unexisting_url(
-    monkeypatch, qv_circ, backend
-):
+def test_routing_unexisting_url(monkeypatch, qv_circ, backend):
     monkeypatch.undo()
     ai_optimize_lf = PassManager(
         [
@@ -129,7 +124,7 @@ def test_routing_unexisting_url(
     except Exception as e:
         print(e)
         assert (
-            "Error: HTTPSConnectionPool(host=\\\'invented-domain-qiskit-transpiler-service-123.com\\\', port=443):"
+            "Error: HTTPSConnectionPool(host=\\'invented-domain-qiskit-transpiler-service-123.com\\', port=443):"
             in str(e)
         )
         assert type(e).__name__ == "TranspilerError"

--- a/tests/ai/test_routing_ai.py
+++ b/tests/ai/test_routing_ai.py
@@ -20,23 +20,6 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit_transpiler_service.ai.routing import AIRouting
 
 
-@pytest.mark.parametrize("layout_mode", ["KEEP", "OPTIMIZE", "IMPROVE"])
-@pytest.mark.parametrize("optimization_level", [1, 2, 3])
-def test_qv_routing(optimization_level, layout_mode, backend, qv_circ):
-    pm = PassManager(
-        [
-            AIRouting(
-                optimization_level=optimization_level,
-                layout_mode=layout_mode,
-                backend_name=backend,
-            )
-        ]
-    )
-    circuit = pm.run(qv_circ)
-
-    assert isinstance(circuit, QuantumCircuit)
-
-
 @pytest.mark.parametrize("optimization_level", [0, 4, 5])
 def test_qv_routing_wrong_opt_level(optimization_level, backend, qv_circ):
     pm = PassManager(
@@ -93,8 +76,8 @@ def test_routing_wrong_token(qv_circ, backend):
         assert "Invalid authentication credentials" in str(e)
 
 
-def test_routing_wrong_url(monkeypatch, qv_circ, backend):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_routing_wrong_url(qv_circ, backend):
     ai_optimize_lf = PassManager(
         [
             AIRouting(backend_name=backend, base_url="https://ibm.com/"),
@@ -108,8 +91,8 @@ def test_routing_wrong_url(monkeypatch, qv_circ, backend):
         assert type(e).__name__ == "JSONDecodeError"
 
 
-def test_routing_unexisting_url(monkeypatch, qv_circ, backend):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_routing_unexisting_url(qv_circ, backend):
     ai_optimize_lf = PassManager(
         [
             AIRouting(
@@ -128,3 +111,20 @@ def test_routing_unexisting_url(monkeypatch, qv_circ, backend):
             in str(e)
         )
         assert type(e).__name__ == "TranspilerError"
+
+
+@pytest.mark.parametrize("layout_mode", ["KEEP", "OPTIMIZE", "IMPROVE"])
+@pytest.mark.parametrize("optimization_level", [1, 2, 3])
+def test_qv_routing(optimization_level, layout_mode, backend, qv_circ):
+    pm = PassManager(
+        [
+            AIRouting(
+                optimization_level=optimization_level,
+                layout_mode=layout_mode,
+                backend_name=backend,
+            )
+        ]
+    )
+    circuit = pm.run(qv_circ)
+
+    assert isinstance(circuit, QuantumCircuit)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,27 +16,28 @@ from qiskit.transpiler.coupling import CouplingMap
 
 
 @pytest.fixture(autouse=True)
-def env_set(monkeypatch):
-    monkeypatch.setenv(
-        "QISKIT_TRANSPILER_SERVICE_PERMUTATIONS_URL",
-        "https://cloud-transpiler-experimental.quantum-computing.ibm.com/permutations",
-    )
-    monkeypatch.setenv(
-        "QISKIT_TRANSPILER_SERVICE_LINEAR_FUNCTIONS_URL",
-        "https://cloud-transpiler-experimental.quantum-computing.ibm.com/linear_functions",
-    )
-    monkeypatch.setenv(
-        "QISKIT_TRANSPILER_SERVICE_CLIFFORD_URL",
-        "https://cloud-transpiler-experimental.quantum-computing.ibm.com/clifford",
-    )
-    monkeypatch.setenv(
-        "QISKIT_TRANSPILER_SERVICE_ROUTING_URL",
-        "https://cloud-transpiler-experimental.quantum-computing.ibm.com/routing",
-    )
-    monkeypatch.setenv(
-        "QISKIT_TRANSPILER_SERVICE_URL",
-        "https://cloud-transpiler-experimental.quantum-computing.ibm.com/",
-    )
+def env_set(monkeypatch, request):
+    if not "disable_monkeypatch" in request.keywords:
+        monkeypatch.setenv(
+            "QISKIT_TRANSPILER_SERVICE_PERMUTATIONS_URL",
+            "https://cloud-transpiler-experimental.quantum-computing.ibm.com/permutations",
+        )
+        monkeypatch.setenv(
+            "QISKIT_TRANSPILER_SERVICE_LINEAR_FUNCTIONS_URL",
+            "https://cloud-transpiler-experimental.quantum-computing.ibm.com/linear_functions",
+        )
+        monkeypatch.setenv(
+            "QISKIT_TRANSPILER_SERVICE_CLIFFORD_URL",
+            "https://cloud-transpiler-experimental.quantum-computing.ibm.com/clifford",
+        )
+        monkeypatch.setenv(
+            "QISKIT_TRANSPILER_SERVICE_ROUTING_URL",
+            "https://cloud-transpiler-experimental.quantum-computing.ibm.com/routing",
+        )
+        monkeypatch.setenv(
+            "QISKIT_TRANSPILER_SERVICE_URL",
+            "https://cloud-transpiler-experimental.quantum-computing.ibm.com/",
+        )
     logging.getLogger("qiskit_transpiler_service.ai.synthesis").setLevel(logging.DEBUG)
 
 

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -203,7 +203,7 @@ def test_transpile_exceed_timeout():
         transpiler_service.run(circuit)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "reached the timeout defined in this client (5s)" in str(e)
+        assert "timed out. Try to update the client's timeout config or review your task" in str(e)
 
 
 def test_transpile_wrong_token():
@@ -235,7 +235,7 @@ def test_transpile_wrong_url():
         transpiler_service.run(circuit)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "reached the timeout defined in this client" in str(e)
+        assert "timed out. Try to update the client's timeout config or review your task" in str(e)
 
 
 def test_transpile_malformed_body():

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -203,7 +203,10 @@ def test_transpile_exceed_timeout():
         transpiler_service.run(circuit)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "timed out. Try to update the client's timeout config or review your task" in str(e)
+        assert (
+            "timed out. Try to update the client's timeout config or review your task"
+            in str(e)
+        )
 
 
 def test_transpile_wrong_token():
@@ -235,7 +238,10 @@ def test_transpile_wrong_url():
         transpiler_service.run(circuit)
         pytest.fail("Error expected")
     except Exception as e:
-        assert "timed out. Try to update the client's timeout config or review your task" in str(e)
+        assert (
+            "timed out. Try to update the client's timeout config or review your task"
+            in str(e)
+        )
 
 
 def test_transpile_malformed_body():

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -190,6 +190,54 @@ def test_transpile_exceed_circuit_size():
         assert str(e) == "'Circuit has more gates than the allowed maximum of 5000.'"
 
 
+def test_transpile_exceed_timeout():
+    circuit = EfficientSU2(100, entanglement="circular", reps=50).decompose()
+    transpiler_service = TranspilerService(
+        backend_name="ibm_kyoto",
+        ai="false",
+        optimization_level=3,
+        timeout=5,
+    )
+
+    try:
+        transpiler_service.run(circuit)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "reached the timeout defined in this client (5s)" in str(e)
+
+
+def test_transpile_wrong_token():
+    circuit = EfficientSU2(100, entanglement="circular", reps=50).decompose()
+    transpiler_service = TranspilerService(
+        backend_name="ibm_kyoto",
+        ai="false",
+        optimization_level=3,
+        token="invented_token5",
+    )
+
+    try:
+        transpiler_service.run(circuit)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert str(e) == "'Invalid authentication credentials'"
+
+
+def test_transpile_wrong_url():
+    circuit = EfficientSU2(100, entanglement="circular", reps=50).decompose()
+    transpiler_service = TranspilerService(
+        backend_name="ibm_kyoto",
+        ai="false",
+        optimization_level=3,
+        base_url="http://wrong-qiskit-transpiler-service-url.com",
+    )
+
+    try:
+        transpiler_service.run(circuit)
+        pytest.fail("Error expected")
+    except Exception as e:
+        assert "reached the timeout defined in this client" in str(e)
+
+
 def test_transpile_malformed_body():
     circuit = EfficientSU2(100, entanglement="circular", reps=1).decompose()
     transpiler_service = TranspilerService(

--- a/tests/test_transpiler_service.py
+++ b/tests/test_transpiler_service.py
@@ -225,8 +225,8 @@ def test_transpile_wrong_token():
         assert str(e) == "'Invalid authentication credentials'"
 
 
-def test_transpile_wrong_url(monkeypatch):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_transpile_wrong_url():
     circuit = EfficientSU2(100, entanglement="circular", reps=1).decompose()
     transpiler_service = TranspilerService(
         backend_name="ibm_kyoto",
@@ -243,8 +243,8 @@ def test_transpile_wrong_url(monkeypatch):
         assert type(e).__name__ == "JSONDecodeError"
 
 
-def test_transpile_unexisting_url(monkeypatch):
-    monkeypatch.undo()
+@pytest.mark.disable_monkeypatch
+def test_transpile_unexisting_url():
     circuit = EfficientSU2(100, entanglement="circular", reps=1).decompose()
     transpiler_service = TranspilerService(
         backend_name="ibm_kyoto",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #22 

This PR enables a programmatic way to setup the timeout for the max polling time. Also, sets up the default value to 300s instead of 600s.


### Details and comments
Apart from enabling the configuration of timeouts, this PR also enables a way to define the `base_url`, the `token` or any other arg in the QiskitTranspilerService class https://github.com/Qiskit/qiskit-transpiler-service/blob/main/qiskit_transpiler_service/wrappers/base.py#L55