### PR TITLE
Simplify GitHub Action (fork PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,12 @@
 name: CI Pipeline
 
-on:
-  pull_request:
-    types: [opened, reopened, edited, ready_for_review, synchronize]
+on: [pull_request]
 
 jobs:
   run-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -38,14 +29,7 @@ jobs:
         python-version: [3.11, 3.8]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Makes better use of GitHub Action's sensible defaults:

* No need to enumerate every type of `pull_request` event. The default already does what you want: running every time you make a change to the PR
* No need to set arguments to `actions/checkout`
    - `fetch_depth: 0` results in fetching every single commit, which gets slow as the repository grows. You probably only need the latest commit to run linters and tests
